### PR TITLE
Element var in properties dialog constructor undefined

### DIFF
--- a/src/scripts/ui/dialogs/properties.coffee
+++ b/src/scripts/ui/dialogs/properties.coffee
@@ -16,8 +16,8 @@ class ContentTools.PropertiesDialog extends ContentTools.DialogUI
 
         # Check the element to determine if the dialog should provide a code
         # editor.
-        @_supportsCoding = element.content
-        if element.constructor.name in ['ListItem', 'TableCell']
+        @_supportsCoding = @element.content
+        if @element.constructor.name in ['ListItem', 'TableCell']
             @_supportsCoding = true
 
     # Methods


### PR DESCRIPTION
When I tried to compile the coffeescript I got an error saying the 'element' var in properties.coffee was undefined. I moved the var to the context of `this` by adding the @ symbol.