### PR TITLE
Adding the possibility to plug in start handlers

### DIFF
--- a/src/scripts/editor.coffee
+++ b/src/scripts/editor.coffee
@@ -452,6 +452,16 @@ class _EditorApp extends ContentTools.ComponentUI
 
         # Set the edtior to busy while we set up
         @busy(true)
+        
+        # allow custom halndlers when the editor is being activated
+        @trigger('start')
+
+        # TODO is there a way to stop the editor initialization
+        # based on a result/user feedback in the `start` handlers?
+        if (false) {
+            @busy(false)
+            return
+        }
 
         # Convert each assigned node to a region
         @_regions = {}


### PR DESCRIPTION
A handy feature (if not supported by other functionality) would be to allow the user to perform custom login when starting the editor. (i.e. checking if there is a user session, etc.). Also (still `TODO` i the code) stop the initialisation of the editor if a certain condition is met.