### PR TITLE
Edge fixes

### DIFF
--- a/external/scripts/content-edit.js
+++ b/external/scripts/content-edit.js
@@ -1433,7 +1433,9 @@
         return range;
       }
       _ref = _getNodeRange(element, docRange), startNode = _ref[0], startOffset = _ref[1], endNode = _ref[2], endOffset = _ref[3];
-      range.set(_getOffsetOfChildNode(element, startNode) + startOffset, _getOffsetOfChildNode(element, endNode) + endOffset);
+      var rangeTo = Math.min(_getOffsetOfChildNode(element, endNode) + endOffset, element.innerText.length);
+      var rangeFrom = _getOffsetOfChildNode(element, startNode) + startOffset;
+      range.set(rangeFrom <= rangeTo ? rangeFrom : 0, rangeTo);
       return range;
     };
 

--- a/src/scripts/ui/dialogs/link.coffee
+++ b/src/scripts/ui/dialogs/link.coffee
@@ -101,6 +101,7 @@ class ContentTools.LinkDialog extends ContentTools.AnchoredDialogUI
         @_domInput.addEventListener 'keypress', (ev) =>
             if ev.keyCode is 13
                 @save()
+                ev.preventDefault()
 
         # Toggle the target attribute for the link ('' or TARGET)
         @_domTargetButton.addEventListener 'click', (ev) =>


### PR DESCRIPTION
Bug fixes for editing in Edge.

- `enter` while finishing a link property replaces selected text with a linebreak.
- Issue #369