### PR TITLE
Update jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ Alternatively you can use `grunt jasmine` to run the tests from the command line
 
 ContentTools is available via the [jsdelivr open source CDN](http://www.jsdelivr.com/), to reference a file from the ContentTools build directory use the following URL format:
 
-`http://cdn.jsdelivr.net/contenttools/{verision}/{file}`
+`http://cdn.jsdelivr.net/npm/ContenTools@{version}/{file}`
 
 For example to access the current primary JavaScript file the URL would be:
 
-`http://cdn.jsdelivr.net/contenttools/1.3.1/content-tools.min.js`
+`https://cdn.jsdelivr.net/npm/ContentTools@1.5.4/build/content-tools.min.js`
 
 As the project's CSS uses relative file paths you will need to either role your own version of CSS from the SASS files (recommended) or [override references to fonts/images within your local CSS](https://gist.github.com/anthonyjb/a6aec8ecfbfe6f875d5c6691687ba43d).
 


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the links now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/ContentTools.

Feel free to ping me if you have any questions regarding this change.