### PR TITLE
Make busy() return the value of @_busy

### DIFF
--- a/src/scripts/editor.coffee
+++ b/src/scripts/editor.coffee
@@ -107,7 +107,7 @@ class _EditorApp extends ContentTools.ComponentUI
 
         # Return the busy flag
         if busy == undefined
-            @_busy = busy
+            return @_busy
 
         # Set the busy flag
         @_busy = busy


### PR DESCRIPTION
I was just reading through the code and saw this. After checking for `undefined` it is just setting `@_busy` instead of returning it as the comment says it should. I suppose the return value is never used or this would have been a problem, but I thought I would go ahead and fix the bug in case it ever came up.