### PR TITLE
Add image pasting ability

### DIFF
--- a/src/scripts/clean-html.coffee
+++ b/src/scripts/clean-html.coffee
@@ -15,7 +15,8 @@ class ContentTools.HTMLCleaner
     # A table of tags and the list of attributes we consider safe for them
     @DEFAULT_ATTRIBUTE_WHITELIST = {
         'a': ['href'],
-        'td': ['colspan']
+        'td': ['colspan'],
+        'img': ['src']
     }
 
     # A default list of tags we consider safe
@@ -30,6 +31,7 @@ class ContentTools.HTMLCleaner
         'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
         'i',
         'ins',
+        'img',
         'li',
         'ol',
         'p',
@@ -64,7 +66,7 @@ class ContentTools.HTMLCleaner
         @attributeWhitelist = attributeWhitelist or
                 @constructor.DEFAULT_ATTRIBUTE_WHITELIST
 
-    clean: (html) ->
+    clean: (html, keepEmpty = false) ->
         # Return a clean version of the given string of HTML
 
         # See https://github.com/GetmeUK/ContentTools/issues/542 for details,
@@ -105,9 +107,9 @@ class ContentTools.HTMLCleaner
                 continue
 
             # Remove any tag with no children or only whitespace children with
-            # the exception of text or <br> tags.
+            # the exception of text or <br> tags, unless "keepEmpty" is defined (e.g. paste image)
             unless nodeName == '#text'
-                if node.textContent.trim() == ''
+                if node.textContent.trim() == '' and !keepEmpty
                     if node.textContent == '' or node.parentNode == wrapper
                         # If the element is empty or top level remove it...
                         node.remove()

--- a/src/scripts/editor.coffee
+++ b/src/scripts/editor.coffee
@@ -201,11 +201,15 @@ class _EditorApp extends ContentTools.ComponentUI
 
             # Non-IE browsers
             if ev.clipboardData
-                if ev.clipboardData.getData('text/html') and
-                        element.type() != 'PreText'
-                    @pasteHTML(element, ev.clipboardData.getData('text/html'))
+                if ev.clipboardData.items and ev.clipboardData.items[0].kind === 'file'
+                    file = ev.clipboardData.items[0].getAsFile();
+                    @dispatchEvent(@createEvent('imagepaste', {file: file, element: element}));
                 else
-                    @pasteText(element, ev.clipboardData.getData('text/plain'))
+                    if ev.clipboardData.getData('text/html') and
+                            element.type() != 'PreText'
+                        @pasteHTML(element, ev.clipboardData.getData('text/html'))
+                    else
+                        @pasteText(element, ev.clipboardData.getData('text/plain'))
 
                 return
 
@@ -349,14 +353,14 @@ class _EditorApp extends ContentTools.ComponentUI
 
     # Page state methods
 
-    pasteHTML: (element, content) ->
+    pasteHTML: (element, content, pasteEmpty = false) ->
         # Paste HTML into/after the given element
         tagNames = ContentEdit.TagNames.get()
 
         # Clean the HTML
         sandbox = document.implementation.createHTMLDocument()
         wrapper = sandbox.createElement('div')
-        wrapper.innerHTML = ContentTools.getHTMLCleaner().clean(content.trim())
+        wrapper.innerHTML = ContentTools.getHTMLCleaner().clean(content.trim(), pasteEmpty)
 
         # Remove any undefined nodes or empty #text nodes
         childNodes = []


### PR DESCRIPTION
I don't know CoffeScript at all, so a thorough review is required, the changes here are reversed from a proven JS implementation I made. If you like it, please adjust accordingly.

Example code for handling the paste event:

```js
  const uploader = function (ev) {
    var formData = new FormData();
    formData.append("image", ev.detail().file);

    var xhr = new XMLHttpRequest();
    xhr.open("POST", "/api/upload");
    xhr.onload = function () {
      if (xhr.status == 200) {
        const response = JSON.parse(xhr.responseText) || {};
        if (ev.detail().element && response.url) {
          editor.pasteHTML(ev.detail().element, `<p><img src="${response.url}"/></p>`, true);
        }
      } else {
        console.log("Nope");
      }
    };

    xhr.send(formData);
  };

  editor.addEventListener("imagepaste", uploader);
```

Or, you can close it, no hard feelings :)
